### PR TITLE
fixed cookie validation

### DIFF
--- a/client/actions/auth.js
+++ b/client/actions/auth.js
@@ -12,7 +12,7 @@ export function validateCookie (redirectUrl) {
     Request
       .get('/auth/user')
       .end((err, resp) => {
-        if (err && err.status === 401 || !resp.body.ok) {
+        if (err && err.status === 401 || !resp.body || !resp.body.ok || !resp.body.login) {
           dispatch({
             type: authActions.CHECK_COOKIE_RESPONSE,
             isLoggedIn: false


### PR DESCRIPTION
@mcdonnelldean it seems that /auth/user is supposed to return ok:true even if the user is not logged in, so this should fix it