### PR TITLE
removed local-auth since it's loaded by seneca-auth by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,12 +52,11 @@
     "redux-thunk": "1.0.x",
     "seneca": "^1.0.0",
     "seneca-auth": "mirceaalexandru/seneca-auth#hapi-express",
-    "seneca-local-auth": "mirceaalexandru/seneca-local-auth",
     "seneca-balance-client": "0.2.0",
     "seneca-mesh": "0.3.0",
     "seneca-pubsub": "^0.1.0",
     "seneca-user": "senecajs/seneca-user.git",
-    "seneca-web": "senecajs/seneca-web",
+    "seneca-web": "mirceaalexandru/seneca-web#hapi",
     "style-loader": "0.13.x",
     "superagent": "1.7.x",
     "varo": "0.3.x"

--- a/server/vidi.js
+++ b/server/vidi.js
@@ -1,7 +1,6 @@
 'use strict'
 
 var Auth = require('seneca-auth')
-var AuthLocal = require('seneca-local-auth')
 
 // Hapi Plugin for wiring up Vidi
 module.exports = function (server, options, next) {
@@ -12,7 +11,6 @@ module.exports = function (server, options, next) {
 
   // set up our own local auth
   seneca.use(Auth, {restrict: '/api'})
-  seneca.use(AuthLocal)
 
   // Set up a default user in concorda
   // timeout is a @hack. I need to know when mesh is available


### PR DESCRIPTION
@mirceaalexandru I made those changes to vidi as well. Also I changed seneca-web to the one it's used by concorda 